### PR TITLE
Remove duplicate inference call in OVOBenchOffline

### DIFF
--- a/utils/OVOBench.py
+++ b/utils/OVOBench.py
@@ -67,7 +67,6 @@ class OVOBenchOffline():
                 chunk_video_path = os.path.join(self.args.chunked_dir, f"{id}.mp4")
                 assert os.path.exists(chunk_video_path)
 
-                response = self.inference(chunk_video_path, prompt)
                 try:
                     response = self.inference(chunk_video_path, prompt)
                 except Exception as e:


### PR DESCRIPTION
Eliminated a redundant call to self.inference before the try-except block in OVOBenchOffline, ensuring inference is only called once and exceptions are properly handled.